### PR TITLE
fix typo in variable

### DIFF
--- a/module-oke-defaults.tf
+++ b/module-oke-defaults.tf
@@ -42,7 +42,7 @@ locals {
     #   node_pool_max_nodes                       = 2
     #   node_k8s_version                          = var.k8s_version
     #   node_pool_shape                           = "BM.GPU.A10.4"
-    #   node_pool_shape_specifc_ad                = 3 # Optional, if not provided or set = 0, will be randomly assigned
+    #   node_pool_shape_specific_ad                = 3 # Optional, if not provided or set = 0, will be randomly assigned
     #   node_pool_node_shape_config_ocpus         = 1
     #   node_pool_node_shape_config_memory_in_gbs = 1
     #   node_pool_boot_volume_size_in_gbs         = "100"

--- a/module-oke.tf
+++ b/module-oke.tf
@@ -115,7 +115,7 @@ module "oke_node_pool" {
   node_pool_max_nodes                       = each.value.node_pool_max_nodes
   node_k8s_version                          = each.value.node_k8s_version
   node_pool_shape                           = each.value.node_pool_shape
-  node_pool_shape_specifc_ad                = each.value.node_pool_shape_specifc_ad
+  node_pool_shape_specific_ad               = each.value.node_pool_shape_specific_ad
   node_pool_node_shape_config_ocpus         = each.value.node_pool_node_shape_config_ocpus
   node_pool_node_shape_config_memory_in_gbs = each.value.node_pool_node_shape_config_memory_in_gbs
   existent_oke_nodepool_id_for_autoscaler   = each.value.existent_oke_nodepool_id_for_autoscaler

--- a/modules/oke-node-pool/datasources.tf
+++ b/modules/oke-node-pool/datasources.tf
@@ -24,7 +24,7 @@ data "oci_identity_availability_domains" "ADs" {
 # Gets a specfic Availability Domain
 data "oci_identity_availability_domain" "specfic" {
   compartment_id = var.tenancy_ocid
-  ad_number      = var.node_pool_shape_specifc_ad
+  ad_number      = var.node_pool_shape_specific_ad
 
-  count = (var.node_pool_shape_specifc_ad > 0) ? 1 : 0
+  count = (var.node_pool_shape_specific_ad > 0) ? 1 : 0
 }

--- a/modules/oke-node-pool/main.tf
+++ b/modules/oke-node-pool/main.tf
@@ -81,5 +81,5 @@ locals {
   node_k8s_version             = (var.node_k8s_version == "Latest") ? local.node_pool_k8s_latest_version : var.node_k8s_version
 
   # Get ADs for the shape to be used on the node pool
-  node_pool_ads = (var.node_pool_shape_specifc_ad > 0) ? data.oci_identity_availability_domain.specfic : data.oci_identity_availability_domains.ADs.availability_domains
+  node_pool_ads = (var.node_pool_shape_specific_ad > 0) ? data.oci_identity_availability_domain.specfic : data.oci_identity_availability_domains.ADs.availability_domains
 }

--- a/modules/oke-node-pool/variables.tf
+++ b/modules/oke-node-pool/variables.tf
@@ -50,13 +50,13 @@ variable "node_pool_node_shape_config_memory_in_gbs" {
   default     = "16" # Only used if flex shape is selected
   description = "You can customize the amount of memory allocated to a flexible shape"
 }
-variable "node_pool_shape_specifc_ad" {
+variable "node_pool_shape_specific_ad" {
   description = "The number of the AD to get the shape for the node pool"
   type        = number
   default     = 0
 
   validation {
-    condition     = var.node_pool_shape_specifc_ad >= 0 && var.node_pool_shape_specifc_ad <= 3
+    condition     = var.node_pool_shape_specific_ad >= 0 && var.node_pool_shape_specific_ad <= 3
     error_message = "Invalid AD number, should be 0 to get all ADs or 1, 2 or 3 to be a specific AD."
   }
 }


### PR DESCRIPTION
This is a typo fix for misspelled `node_pool_shape_specifc_ad` instead of `node_pool_shape_specific_ad`.

This was producing the following error on OCI Resource Manager:

```
Error: Unsupported attribute
  on module-oke.tf line 118, in module "oke_node_pool" 
 118:   node_pool_shape_specifc_ad                = each.value.node_pool_shape_specifc_ad
    ├────────────────
    │ each.value is object with 14 attributes
This object does not have an attribute named "node_pool_shape_specifc_ad". 
```

